### PR TITLE
Wrong assignment of values

### DIFF
--- a/fraud-detection/data/transaction_features/new_balance_orig.sql
+++ b/fraud-detection/data/transaction_features/new_balance_orig.sql
@@ -10,5 +10,5 @@
 
 SELECT transactionId,
        if(oldbalanceOrg == 0 and newbalanceOrig == 0 and amount != 0, -1,
-           oldbalanceDest) as new_balance_orig
+           newbalanceOrig) as new_balance_orig
 FROM transactions

--- a/fraud-detection/data/transaction_features/old_balance_orig.sql
+++ b/fraud-detection/data/transaction_features/old_balance_orig.sql
@@ -10,5 +10,5 @@
 
 SELECT transactionId,
        if(oldbalanceOrg == 0 and newbalanceOrig == 0 and amount != 0, -1,
-          oldbalanceDest) as old_balance_orig
+          oldbalanceOrg) as old_balance_orig
 FROM transactions


### PR DESCRIPTION
Two sql files in the transaction_features folder of the fraud-detection example assigned the wrong value to the output column as shown below:

oldbalanceDest as old_balance_orig
oldbalanceDest as new_balance_orig