### PR TITLE
Update the layer integration name to layer-public-datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains example projects that you can use to get started with [
 
 ### Note:
 To run any of the example projects, users need to create their own integration.
-All examples currently expect organization:
+All examples currently expect the integration:
 
-    target: layer
+    target: layer-public-datasets
 
-Where `layer` is an integration name.
-Integration `name` must be unique across organization.
+Where `layer-public-datasets` is an integration name.
+Integration `name` must be unique across the organization.

--- a/cats-and-dogs-classification/data/dataset/dataset.yaml
+++ b/cats-and-dogs-classification/data/dataset/dataset.yaml
@@ -12,5 +12,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "catsdogs"

--- a/cats-and-dogs-classification/data/features/dataset.yml
+++ b/cats-and-dogs-classification/data/features/dataset.yml
@@ -19,4 +19,4 @@ schema:
   primary_keys: ["id"]
 
 materializations:
-  - target: layer
+  - target: layer-public-datasets

--- a/churn-prediction/data/event_log/dataset.yaml
+++ b/churn-prediction/data/event_log/dataset.yaml
@@ -12,5 +12,5 @@ type: source
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "event_log"

--- a/churn-prediction/data/user_features/dataset.yml
+++ b/churn-prediction/data/user_features/dataset.yml
@@ -56,4 +56,4 @@ schema:
   primary_keys: ["userId"]
 
 materializations:
-  - target: layer
+  - target: layer-public-datasets

--- a/custom-keras-loss-function/data/dataset/dataset.yaml
+++ b/custom-keras-loss-function/data/dataset/dataset.yaml
@@ -7,5 +7,5 @@ schema:
   primary_keys: ["id"]
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "house_prices_train"

--- a/empty/data/dataset/dataset.yaml
+++ b/empty/data/dataset/dataset.yaml
@@ -12,5 +12,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "dataset"

--- a/fraud-detection/data/transaction_features/dataset.yml
+++ b/fraud-detection/data/transaction_features/dataset.yml
@@ -44,4 +44,4 @@ schema:
   primary_keys: ["transactionId"]
 
 materializations:
-  - target: layer
+  - target: layer-public-datasets

--- a/fraud-detection/data/transactions/dataset.yaml
+++ b/fraud-detection/data/transactions/dataset.yaml
@@ -14,5 +14,5 @@ type: source
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "transactions_log"

--- a/random-forest-regression/data/dataset/dataset.yaml
+++ b/random-forest-regression/data/dataset/dataset.yaml
@@ -7,5 +7,5 @@ schema:
   primary_keys: ["id"]
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "house_prices_train"

--- a/spam-detection/data/sms_featureset/dataset.yml
+++ b/spam-detection/data/sms_featureset/dataset.yml
@@ -23,4 +23,4 @@ schema:
   primary_keys: ["id"]
 
 materializations:
-  - target: layer
+  - target: layer-public-datasets

--- a/spam-detection/data/spam_data/dataset.yml
+++ b/spam-detection/data/spam_data/dataset.yml
@@ -9,5 +9,5 @@ type: source
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "spam_messages"

--- a/titanic-hyperparametertuning/data/passenger_features/dataset.yml
+++ b/titanic-hyperparametertuning/data/passenger_features/dataset.yml
@@ -41,5 +41,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: passengers

--- a/titanic-hyperparametertuning/data/titanic_data/dataset.yaml
+++ b/titanic-hyperparametertuning/data/titanic_data/dataset.yaml
@@ -16,5 +16,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "titanic"

--- a/titanic-spark/data/passenger_features/dataset.yml
+++ b/titanic-spark/data/passenger_features/dataset.yml
@@ -41,5 +41,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: passengers

--- a/titanic-spark/data/titanic_data/dataset.yaml
+++ b/titanic-spark/data/titanic_data/dataset.yaml
@@ -16,5 +16,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "titanic"

--- a/titanic/data/passenger_features/dataset.yml
+++ b/titanic/data/passenger_features/dataset.yml
@@ -41,5 +41,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: passengers

--- a/titanic/data/titanic_data/dataset.yaml
+++ b/titanic/data/titanic_data/dataset.yaml
@@ -16,5 +16,5 @@ schema:
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "titanic"

--- a/word-embeddings/data/spam_data/dataset.yml
+++ b/word-embeddings/data/spam_data/dataset.yml
@@ -9,5 +9,5 @@ type: source
 
 materializations:
   - type: table
-    target: layer
+    target: layer-public-datasets
     table_name: "spam_messages"


### PR DESCRIPTION
Update the `layer` integration name to `layer-public-datasets` to match the one automatically created for new organizations.