### PR TITLE
Remove nonfunctional keys from the dataset yaml files

### DIFF
--- a/cats-and-dogs-classification/data/dataset/dataset.yaml
+++ b/cats-and-dogs-classification/data/dataset/dataset.yaml
@@ -7,10 +7,6 @@ apiVersion: 1
 name: "catsdogs"
 type: source
 
-schema:
-  primary_keys: []
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "catsdogs"

--- a/cats-and-dogs-classification/data/features/dataset.yml
+++ b/cats-and-dogs-classification/data/features/dataset.yml
@@ -12,11 +12,5 @@ features:
     source: category/category.py
     environment: category/requirements.txt
 
-
-schema:
-  # All of the sms_features above should include this primary key. It will be used to join the sms_features
-  # together.
-  primary_keys: ["id"]
-
-materializations:
-  - target: layer-public-datasets
+materialization:
+    target: layer-public-datasets

--- a/churn-prediction/data/event_log/dataset.yaml
+++ b/churn-prediction/data/event_log/dataset.yaml
@@ -10,7 +10,6 @@ apiVersion: 1
 name: "events"
 type: source
 
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "event_log"

--- a/churn-prediction/data/user_features/dataset.yml
+++ b/churn-prediction/data/user_features/dataset.yml
@@ -49,11 +49,5 @@ features:
     description: "Churn flag of users (1= Churned, 0= Not)"
     source: is_churned.sql
 
-
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["userId"]
-
-materializations:
-  - target: layer-public-datasets
+materialization:
+    target: layer-public-datasets

--- a/custom-keras-loss-function/data/dataset/dataset.yaml
+++ b/custom-keras-loss-function/data/dataset/dataset.yaml
@@ -3,9 +3,7 @@ apiVersion: 1
 # refer to this dataset
 name: "house_prices_train"
 type: source
-schema:
-  primary_keys: ["id"]
-materializations:
-  - type: table
+
+materialization:
     target: layer-public-datasets
     table_name: "house_prices_train"

--- a/custom-keras-loss-function/data/features/dataset.yml
+++ b/custom-keras-loss-function/data/features/dataset.yml
@@ -40,11 +40,5 @@ features:
     description: "BedroomAbvGr"
     source: BedroomAbvGr.py
     environment: requirements.txt
-    
-  
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["Id"]
 
-materializations: []
+materialization:

--- a/custom-keras-loss-function/data/features/dataset.yml
+++ b/custom-keras-loss-function/data/features/dataset.yml
@@ -42,3 +42,4 @@ features:
     environment: requirements.txt
 
 materialization:
+    target: layer-public-datasets

--- a/empty/data/dataset/dataset.yaml
+++ b/empty/data/dataset/dataset.yaml
@@ -7,10 +7,6 @@ apiVersion: 1
 name: "dataset"
 type: source
 
-schema:
-  primary_keys: []
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "dataset"

--- a/empty/data/features/dataset.yml
+++ b/empty/data/features/dataset.yml
@@ -14,3 +14,4 @@ description: "My Features"
 features: []
 
 materialization:
+    target: layer-public-datasets

--- a/empty/data/features/dataset.yml
+++ b/empty/data/features/dataset.yml
@@ -13,9 +13,4 @@ description: "My Features"
 
 features: []
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: []
-
-materializations: []
+materialization:

--- a/fraud-detection/data/transaction_features/dataset.yml
+++ b/fraud-detection/data/transaction_features/dataset.yml
@@ -38,10 +38,5 @@ features:
      DEBIT=3, PAYMENT=4)"
     source: type.sql
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["transactionId"]
-
-materializations:
-  - target: layer-public-datasets
+materialization:
+    target: layer-public-datasets

--- a/fraud-detection/data/transactions/dataset.yaml
+++ b/fraud-detection/data/transactions/dataset.yaml
@@ -12,7 +12,6 @@ apiVersion: 1
 name: "transactions"
 type: source
 
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "transactions_log"

--- a/random-forest-regression/data/dataset/dataset.yaml
+++ b/random-forest-regression/data/dataset/dataset.yaml
@@ -3,9 +3,7 @@ apiVersion: 1
 # refer to this dataset
 name: "house_prices_train"
 type: source
-schema:
-  primary_keys: ["id"]
-materializations:
-  - type: table
+
+materialization:
     target: layer-public-datasets
     table_name: "house_prices_train"

--- a/random-forest-regression/data/features/dataset.yml
+++ b/random-forest-regression/data/features/dataset.yml
@@ -41,10 +41,4 @@ features:
     source: BedroomAbvGr.py
     environment: requirements.txt
 
-
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["Id"]
-
-materializations: []
+materialization:

--- a/random-forest-regression/data/features/dataset.yml
+++ b/random-forest-regression/data/features/dataset.yml
@@ -42,3 +42,4 @@ features:
     environment: requirements.txt
 
 materialization:
+    target: layer-public-datasets

--- a/spam-detection/data/sms_featureset/dataset.yml
+++ b/spam-detection/data/sms_featureset/dataset.yml
@@ -17,10 +17,5 @@ features:
     source: message/feature.py
     environment: message/requirements.txt
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["id"]
-
-materializations:
-  - target: layer-public-datasets
+materialization:
+    target: layer-public-datasets

--- a/spam-detection/data/spam_data/dataset.yml
+++ b/spam-detection/data/spam_data/dataset.yml
@@ -7,7 +7,6 @@ apiVersion: 1
 name: "spam_messages"
 type: source
 
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "spam_messages"

--- a/titanic-hyperparametertuning/data/passenger_features/dataset.yml
+++ b/titanic-hyperparametertuning/data/passenger_features/dataset.yml
@@ -36,4 +36,3 @@ features:
 
 materialization:
     target: layer-public-datasets
-    table_name: passengers

--- a/titanic-hyperparametertuning/data/passenger_features/dataset.yml
+++ b/titanic-hyperparametertuning/data/passenger_features/dataset.yml
@@ -34,12 +34,6 @@ features:
     description: "Whether the user survived or not."
     source: survived.sql
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["PassengerId"]
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: passengers

--- a/titanic-hyperparametertuning/data/titanic_data/dataset.yaml
+++ b/titanic-hyperparametertuning/data/titanic_data/dataset.yaml
@@ -11,10 +11,6 @@ apiVersion: 1
 name: "titanic"
 type: source
 
-schema:
-  primary_keys: ["PassengerId"]
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "titanic"

--- a/titanic-spark/data/passenger_features/dataset.yml
+++ b/titanic-spark/data/passenger_features/dataset.yml
@@ -34,12 +34,6 @@ features:
     description: "Whether the passenger survived or not."
     source: survived.sql
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["PassengerId"]
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: passengers

--- a/titanic-spark/data/passenger_features/dataset.yml
+++ b/titanic-spark/data/passenger_features/dataset.yml
@@ -36,4 +36,3 @@ features:
 
 materialization:
     target: layer-public-datasets
-    table_name: passengers

--- a/titanic-spark/data/titanic_data/dataset.yaml
+++ b/titanic-spark/data/titanic_data/dataset.yaml
@@ -11,10 +11,6 @@ apiVersion: 1
 name: "titanic"
 type: source
 
-schema:
-  primary_keys: ["PassengerId"]
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "titanic"

--- a/titanic/data/passenger_features/dataset.yml
+++ b/titanic/data/passenger_features/dataset.yml
@@ -34,12 +34,6 @@ features:
     description: "Whether the passenger survived or not."
     source: survived.sql
 
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["PassengerId"]
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: passengers

--- a/titanic/data/passenger_features/dataset.yml
+++ b/titanic/data/passenger_features/dataset.yml
@@ -36,4 +36,3 @@ features:
 
 materialization:
     target: layer-public-datasets
-    table_name: passengers

--- a/titanic/data/titanic_data/dataset.yaml
+++ b/titanic/data/titanic_data/dataset.yaml
@@ -11,10 +11,6 @@ apiVersion: 1
 name: "titanic"
 type: source
 
-schema:
-  primary_keys: ["PassengerId"]
-
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "titanic"

--- a/word-embeddings/data/sms_featureset/dataset.yml
+++ b/word-embeddings/data/sms_featureset/dataset.yml
@@ -16,10 +16,3 @@ features:
     description: "Messages"
     source: message/feature.py
     environment: message/requirements.txt
-
-schema:
-  # All of the features above should include this primary key. It will be used to join the features
-  # together.
-  primary_keys: ["id"]
-
-

--- a/word-embeddings/data/sms_featureset/dataset.yml
+++ b/word-embeddings/data/sms_featureset/dataset.yml
@@ -16,3 +16,6 @@ features:
     description: "Messages"
     source: message/feature.py
     environment: message/requirements.txt
+
+materialization:
+    target: layer-public-datasets

--- a/word-embeddings/data/spam_data/dataset.yml
+++ b/word-embeddings/data/spam_data/dataset.yml
@@ -7,7 +7,6 @@ apiVersion: 1
 name: "spam_messages"
 type: source
 
-materializations:
-  - type: table
+materialization:
     target: layer-public-datasets
     table_name: "spam_messages"


### PR DESCRIPTION
We updated the yaml validation in sdk (`0.8.1`) mainly the materialization key for the dataset yaml.
- `schema` key is not functional. (removed)
- `materialization` is a single object instead of a list. (updated)
- `type` key under `materialization` is not functional. (removed)
- `table_name` key under `materialization` for `featuresets` is not functional. (removed)

Note: New release is backward compatible, so old projects would still work.