### PR TITLE
Update the fabric definition for the titanic-spark model

### DIFF
--- a/titanic-spark/README.md
+++ b/titanic-spark/README.md
@@ -8,6 +8,7 @@ A classification example with `Spark ML` for predicting the survivals of the Tit
 - Utilize `SparkSession` from Layer `Context` for Spark SQL queries (i.e. `title` feature)
 - Convert Spark DataFrames into Pandas DataFrames as the way Layer stores the features
 - Load `passenger` features and use it to train our `survival` model
+- Run the model in a Spark cluster, as specified by the `fabric` setting 
 - Experimentation tracking with
     - logging `BinaryClassificationEvaluator` metric
 

--- a/titanic-spark/models/survival_model/model.yaml
+++ b/titanic-spark/models/survival_model/model.yaml
@@ -10,5 +10,5 @@ training:
   entrypoint: model.py
   # File includes the required python libraries with their correct versions
   environment: requirements.txt
-  fabric:
-    type: spark
+  fabric: f-spark-small
+  


### PR DESCRIPTION
This PR updates the fabric definition for the `titanic-spark` example to follow the unified convention for `fabric` specification in Layer.